### PR TITLE
Libpython3.5.so 1

### DIFF
--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -20,10 +20,10 @@ RUN set -x \
     && gpg --verify python.tar.xz.asc \
     && tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
     && rm python.tar.xz* \
-    && cd /usr/src/python \    
-    && ./configure \
+    && cd /usr/src/python \
+    && ./configure --enable-shared \
     && make -j$(nproc) && make altinstall \
-    && ldconfig \
+    && echo "/usr/local/lib/" > /etc/ld.so.conf.d/local.conf && ldconfig \
     && pip3.5 install --no-cache-dir --upgrade --ignore-installed pip==$PYTHON_PIP_VERSION \
     && find /usr/local \
         \( -type d -a -name test -o -name tests \) \
@@ -40,3 +40,4 @@ RUN cd /usr/local/bin \
     && ln -s python-config3.5 python-config3
 
 CMD ["python3"]
+

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -8,10 +8,10 @@ ENV LANG C.UTF-8
 # gpg: key F73C700D: public key "Larry Hastings <larry@hastings.org>" imported
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 
-ENV PYTHON_VERSION 3.5.0
+ENV PYTHON_VERSION 3.5.3
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 7.1.2
+ENV PYTHON_PIP_VERSION 9.0.1
 
 RUN set -x \
     && mkdir -p /usr/src/python \


### PR DESCRIPTION
Add `--enable-shared` flag to the configure script of Python source build. This resolves issues for applications that require an embedded Python environment (e.g. pybuilder or pyinstaller).