### PR TITLE
Support for Python 3.6

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,0 +1,44 @@
+FROM mbaltrusitis/centos-buildpack-deps:7
+MAINTAINER Matthew Baltrusitis "matthew@baltrusitis.com"
+
+# http://bugs.python.org/issue19846
+# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+ENV LANG C.UTF-8
+
+# gpg: key F73C700D: public key "Larry Hastings <larry@hastings.org>" imported
+RUN curl -SL "https://www.python.org/static/files/pubkeys.txt" -o pubkeys.txt \
+    && gpg --import pubkeys.txt
+
+ENV PYTHON_VERSION 3.6.0
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 9.0.1
+
+RUN set -x \
+    && mkdir -p /usr/src/python \
+    && curl -SL "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" -o python.tar.xz \
+    && curl -SL "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" -o python.tar.xz.asc \
+    && gpg --verify python.tar.xz.asc \
+    && tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+    && rm python.tar.xz* \
+    && cd /usr/src/python \
+    && ./configure --enable-shared \
+    && make -j$(nproc) && make altinstall \
+    && echo "/usr/local/lib/" > /etc/ld.so.conf.d/local.conf && ldconfig \
+    && pip3.6 install --no-cache-dir --upgrade --ignore-installed pip==$PYTHON_PIP_VERSION \
+    && find /usr/local \
+        \( -type d -a -name test -o -name tests \) \
+        -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+        -exec rm -rf '{}' + \
+    && rm -rf /usr/src/python
+
+# make some useful symlinks that are expected to exist
+RUN cd /usr/local/bin \
+    && ln -s easy_install-3.6 easy_install3 \
+    && ln -s idle3.6 idle3 \
+    && ln -s pydoc3.6 pydoc3 \
+    && ln -s python3.6 python3 \
+    && ln -s python-config3.6 python-config3
+
+CMD ["python3"]
+

--- a/3.6/onbuild/Dockerfile
+++ b/3.6/onbuild/Dockerfile
@@ -1,0 +1,9 @@
+FROM mbaltrusitis/centos-python:3.6
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY requirements.txt /usr/src/app/
+ONBUILD RUN pip3 install --no-cache-dir -r requirements.txt
+
+ONBUILD COPY . /usr/src/app

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ This Dockerfile is a port to [CentOS](http://www.centos.org/) from Debian's [doc
 - [`2.7.10-onbuild`, `2.7-onbuild`, `2-onbuild` (*2.7/onbuild/Dockerfile*)](https://github.com/mbaltrusitis/dockerfile-centos-python/blob/master/2.7/onbuild/Dockerfile)
 - [`3.4.3`, `3.4` (*3.4/Dockerfile*)](https://github.com/mbaltrusitis/dockerfile-centos-python/blob/master/3.4/Dockerfile)
 - [`3.4.3-onbuild`, `3.4-onbuild`, `3.4.3-onbuild` (*3.4/onbuild/Dockerfile*)](https://github.com/mbaltrusitis/dockerfile-centos-python/blob/master/3.4/onbuild/Dockerfile)
-- [`3.5.0`, `3.5`, `3` (*3.5/Dockerfile*)](https://github.com/mbaltrusitis/dockerfile-centos-python/blob/master/3.5/Dockerfile)
-- [`3.5.0-onbuild`, `3.5-onbuild`, `3-onbuild` (*3.5/onbuild/Dockerfile*)](https://github.com/mbaltrusitis/dockerfile-centos-python/blob/master/3.5/onbuild/Dockerfile)
+- [`3.5.0`, `3.5`, (*3.5/Dockerfile*)](https://github.com/mbaltrusitis/dockerfile-centos-python/blob/master/3.5/Dockerfile)
+- [`3.5.0-onbuild`, `3.5-onbuild`, (*3.5/onbuild/Dockerfile*)](https://github.com/mbaltrusitis/dockerfile-centos-python/blob/master/3.5/onbuild/Dockerfile)
+- [`3.6.0`, `3.6`, `3` (*3.6/Dockerfile*)](https://github.com/mbaltrusitis/dockerfile-centos-python/blob/master/3.6/Dockerfile)
+- [`3.6.0-onbuild`, `3.6-onbuild`, `3-onbuild` (*3.6/onbuild/Dockerfile*)](https://github.com/mbaltrusitis/dockerfile-centos-python/blob/master/3.6/onbuild/Dockerfile)
 
 ## How to use `onbuild`
 


### PR DESCRIPTION
This also sees the new `--enable-shared` switch in the source configuration.